### PR TITLE
[Z80] Add registers definition I, R, MB

### DIFF
--- a/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
@@ -176,7 +176,7 @@ const TargetRegisterClass *
 Z80InstructionSelector::getRegClass(Register Reg,
                                     MachineRegisterInfo &MRI) const {
   if (Reg.isPhysical()) {
-    for (auto *RC : {&Z80::R8RegClass, &Z80::F8RegClass, &Z80::R16RegClass,
+    for (auto *RC : {&Z80::R8RegClass, &Z80::Z8RegClass, &Z80::R16RegClass,
                      &Z80::Z16RegClass, &Z80::R24RegClass, &Z80::Z24RegClass})
       if (RC->contains(Reg))
         return RC;
@@ -226,8 +226,9 @@ bool Z80InstructionSelector::selectCopy(MachineInstr &I,
   if (DstReg.isPhysical()) {
     assert(I.isCopy() && "Generic operators do not allow physical registers");
 
-    if (DstReg == Z80::F &&
-        !RBI.constrainGenericRegister(SrcReg, Z80::F8RegClass, MRI))
+    if ((DstReg == Z80::F || DstReg == Z80::I || DstReg == Z80::R ||
+         DstReg == Z80::MB) &&
+        !RBI.constrainGenericRegister(SrcReg, Z80::Z8RegClass, MRI))
       return false;
 
     if (DstSize > SrcSize && SrcRegBank.getID() == Z80::GPRRegBankID &&
@@ -1226,8 +1227,8 @@ Z80InstructionSelector::foldCompare(MachineInstr &I, MachineIRBuilder &MIB,
                                          CallLowering::ArgInfo::NoArgIndex);
     createLibcall(MIB, RTLIB::SCMP, SignedFlagsArg, FlagsArg);
     MIB.buildCopy(Register(Z80::F), SignedFlagsReg);
-    if (!RBI.constrainGenericRegister(FlagsReg, Z80::F8RegClass, MRI) ||
-        !RBI.constrainGenericRegister(SignedFlagsReg, Z80::F8RegClass, MRI))
+    if (!RBI.constrainGenericRegister(FlagsReg, Z80::Z8RegClass, MRI) ||
+        !RBI.constrainGenericRegister(SignedFlagsReg, Z80::Z8RegClass, MRI))
       return Z80::COND_INVALID;
   }
   return CC;

--- a/llvm/lib/Target/Z80/GISel/Z80RegisterBankInfo.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80RegisterBankInfo.cpp
@@ -46,7 +46,7 @@ Z80RegisterBankInfo::getRegBankFromRegClass(const TargetRegisterClass &RC,
   if (Z80::R8RegClass.hasSubClassEq(&RC) ||
       Z80::R16RegClass.hasSubClassEq(&RC) ||
       Z80::R24RegClass.hasSubClassEq(&RC) ||
-      Z80::F8RegClass.hasSubClassEq(&RC) ||
+      Z80::Z8RegClass.hasSubClassEq(&RC) ||
       Z80::Z16RegClass.hasSubClassEq(&RC) ||
       Z80::Z24RegClass.hasSubClassEq(&RC))
     return getRegBank(Z80::GPRRegBankID);

--- a/llvm/lib/Target/Z80/Z80ISelLowering.cpp
+++ b/llvm/lib/Target/Z80/Z80ISelLowering.cpp
@@ -632,7 +632,7 @@ Z80TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
     }
 
   if (Z80::parseConstraintCode(Constraint) != Z80::COND_INVALID)
-    return std::make_pair(Z80::F, &Z80::F8RegClass);
+    return std::make_pair(Z80::F, &Z80::Z8RegClass);
 
   // Use the default implementation in TargetLowering to convert the register
   // constraint into a member of a register class.
@@ -640,7 +640,7 @@ Z80TargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
 
   if (!Res.second) {
     if (Constraint.equals_insensitive("{f}"))
-      return std::make_pair(Z80::F, &Z80::F8RegClass);
+      return std::make_pair(Z80::F, &Z80::Z8RegClass);
 
     return Res;
   }

--- a/llvm/lib/Target/Z80/Z80MachineEarlyOptimization.cpp
+++ b/llvm/lib/Target/Z80/Z80MachineEarlyOptimization.cpp
@@ -154,7 +154,7 @@ bool Z80MachineEarlyOptimization::runOnMachineFunction(MachineFunction &MF) {
             }
           }
           if (CallMI && Cost < CondCallThreshold) {
-            Register TempReg = MRI.createVirtualRegister(&Z80::F8RegClass);
+            Register TempReg = MRI.createVirtualRegister(&Z80::Z8RegClass);
             DebugLoc DL = MBB.findBranchDebugLoc();
             MBB.removeSuccessor(FalseMBB);
             TII.removeBranch(MBB);

--- a/llvm/lib/Target/Z80/Z80RegisterBanks.td
+++ b/llvm/lib/Target/Z80/Z80RegisterBanks.td
@@ -10,4 +10,4 @@
 //===----------------------------------------------------------------------===//
 
 /// General Purpose Registers
-def GPRRegBank : RegisterBank<"GPR", [R24, Z24, Z16, F8]>;
+def GPRRegBank : RegisterBank<"GPR", [R24, Z24, Z16, Z8]>;

--- a/llvm/lib/Target/Z80/Z80RegisterInfo.td
+++ b/llvm/lib/Target/Z80/Z80RegisterInfo.td
@@ -53,7 +53,7 @@ let Namespace = "Z80" in {
 //===----------------------------------------------------------------------===//
 //  Register definitions...
 //
-
+let Namespace = "Z80" in {
 // 8-bit registers
 def A : Z80Reg<"a", 7>;
 def F : Z80Reg<"f">;
@@ -63,6 +63,11 @@ def D : Z80Reg<"d", 2>;
 def E : Z80Reg<"e", 3>;
 def H : Z80Reg<"h", 4>;
 def L : Z80Reg<"l", 5>;
+
+// special registers
+def I : Z80Reg<"i", 8>;
+def R : Z80Reg<"r", 9>;
+def MB : Z80Reg<"mb", 10>;
 
 // 8-bit index registers
 let CostPerUse = [1] in {
@@ -96,13 +101,10 @@ let CostPerUse = [1] in {
   def UIX : EZ80ExtReg<IX>;
   def UIY : EZ80ExtReg<IY>;
 }
-
-// 24-bit misc registers
-def SPL : Z80Reg<"sp", 3>, DwarfRegNum<[7]>;
-
-// misc registers
-def PC  : Z80Reg<"pc">, DwarfRegNum<[8]>;
-
+}
+def SPL : Z80Reg<"sp", 3>;
+def PC  : Z80Reg<"pc">;
+}
 //===----------------------------------------------------------------------===//
 //  Register Class Definitions...
 //

--- a/llvm/lib/Target/Z80/Z80RegisterInfo.td
+++ b/llvm/lib/Target/Z80/Z80RegisterInfo.td
@@ -53,7 +53,7 @@ let Namespace = "Z80" in {
 //===----------------------------------------------------------------------===//
 //  Register definitions...
 //
-let Namespace = "Z80" in {
+
 // 8-bit registers
 def A : Z80Reg<"a", 7>;
 def F : Z80Reg<"f">;
@@ -63,11 +63,6 @@ def D : Z80Reg<"d", 2>;
 def E : Z80Reg<"e", 3>;
 def H : Z80Reg<"h", 4>;
 def L : Z80Reg<"l", 5>;
-
-// special registers
-def I : Z80Reg<"i", 8>;
-def R : Z80Reg<"r", 9>;
-def MB : Z80Reg<"mb", 10>;
 
 // 8-bit index registers
 let CostPerUse = [1] in {
@@ -101,10 +96,18 @@ let CostPerUse = [1] in {
   def UIX : EZ80ExtReg<IX>;
   def UIY : EZ80ExtReg<IY>;
 }
-}
-def SPL : Z80Reg<"sp", 3>;
-def PC  : Z80Reg<"pc">;
-}
+
+// 24-bit misc registers
+def SPL : Z80Reg<"sp", 3>, DwarfRegNum<[7]>;
+
+// misc registers
+def PC : Z80Reg<"pc">, DwarfRegNum<[8]>;
+def I  : Z80Reg<"i">;
+let SubRegs = [I], SubRegIndices = [sub_low] in
+def UI : Z80Reg<"i">;
+def R  : Z80Reg<"r">;
+def MB : Z80Reg<"mb">;
+
 //===----------------------------------------------------------------------===//
 //  Register Class Definitions...
 //
@@ -120,7 +123,7 @@ def X8  : Z80RC8 <(add O8, IXL, IXH)>;
 def I8  : Z80RC8 <(add IYL, IYH, IXL, IXH)>;
 def R8  : Z80RC8 <(add G8, I8)>;
 let CopyCost = -1 in
-def F8  : Z80RC8 <(add F)>;
+def Z8  : Z80RC8 <(add F, I, R, MB)>;
 
 def O16 : Z80RC16<(add DE, BC)>;
 def G16 : Z80RC16<(add HL, O16)>;
@@ -130,7 +133,7 @@ def I16 : Z80RC16<(add IY, IX)>;
 def A16 : Z80RC16<(add HL, I16)>;
 def R16 : Z80RC16<(add G16, I16)>;
 let CopyCost = -1 in
-def Z16 : Z80RC16<(add SPS, AF)>;
+def Z16 : Z80RC16<(add SPS, AF, UI)>;
 
 def O24 : Z80RC24<(add UDE, UBC)>;
 def G24 : Z80RC24<(add UHL, O24)>;


### PR DESCRIPTION
This change adds support for special registers, may be useful for AsmParser later (it requires to rename registers to have unique names).

Also, enable Issues please. There is error while compiling:
fatal error: error in backend: unable to legalize instruction: %36:_(s16) = G_PHI %2:_(s16), %bb.1, %34:_(s16), %bb.3 (in function: crc)
