### PR TITLE
[Z80] Add feature to enable SLI/SLL instruction

### DIFF
--- a/llvm/lib/Target/Z80/Z80.td
+++ b/llvm/lib/Target/Z80/Z80.td
@@ -28,7 +28,7 @@ def FeatureEZ80    : SubtargetFeature<"ez80", "HasEZ80Ops", "true",
                                       "Support ez80 instructions">;
 def FeatureIdxHalf : SubtargetFeature<"idxhalf", "HasIdxHalfRegs", "true",
                                       "Support index half registers">;
-def FeatureSli     : SubtargetFeature<"sli", "HasSliOps", "true",
+def FeatureSli     : SubtargetFeature<"sli", "HasSliOp", "true",
                                       "Support SLI instruction">;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Z80/Z80.td
+++ b/llvm/lib/Target/Z80/Z80.td
@@ -28,6 +28,8 @@ def FeatureEZ80    : SubtargetFeature<"ez80", "HasEZ80Ops", "true",
                                       "Support ez80 instructions">;
 def FeatureIdxHalf : SubtargetFeature<"idxhalf", "HasIdxHalfRegs", "true",
                                       "Support index half registers">;
+def FeatureSli     : SubtargetFeature<"sli", "HasSliOps", "true",
+                                      "Support SLI instruction">;
 
 //===----------------------------------------------------------------------===//
 // Z80 Subtarget state
@@ -46,7 +48,7 @@ let CompleteModel = 0 in def GenericModel : SchedMachineModel;
 class Proc<string Name, list<SubtargetFeature> Features>
   : ProcessorModel<Name, GenericModel, Features>;
 def : Proc<"generic",     []>;
-def : Proc<"z80",         [FeatureUndoc, FeatureIdxHalf]>;
+def : Proc<"z80",         [FeatureUndoc, FeatureIdxHalf, FeatureSli]>;
 def : Proc<"z180",        [FeatureZ180]>;
 def : Proc<"ez80",        [FeatureZ180, FeatureEZ80, FeatureIdxHalf]>;
 

--- a/llvm/lib/Target/Z80/Z80InstrInfo.td
+++ b/llvm/lib/Target/Z80/Z80InstrInfo.td
@@ -82,6 +82,7 @@ def Z80rl_flag       : SDNode<"Z80ISD::RL",      SDTUnOpRFF>;
 def Z80rr_flag       : SDNode<"Z80ISD::RR",      SDTUnOpRFF>;
 def Z80sla_flag      : SDNode<"Z80ISD::SLA",     SDTUnOpRF>;
 def Z80sra_flag      : SDNode<"Z80ISD::SRA",     SDTUnOpRF>;
+def Z80sli_flag      : SDNode<"Z80ISD::SLI",     SDTUnOpRF>;
 def Z80srl_flag      : SDNode<"Z80ISD::SRL",     SDTUnOpRF>;
 def Z80bit_flag      : SDNode<"Z80ISD::BIT",     SDTBitOpF>;
 def Z80res_flag      : SDNode<"Z80ISD::RES",     SDTBitOpR>;
@@ -132,8 +133,9 @@ def HaveZ180Ops  : Predicate<"Subtarget->hasZ180Ops()">,
 def HaveEZ80Ops  : Predicate<"Subtarget->hasEZ80Ops()">,
                    AssemblerPredicate<(all_of FeatureEZ80), "eZ80 ops">;
 def HaveIdxHalf  : Predicate<"Subtarget->hasIndexHalfRegs()">,
-                   AssemblerPredicate<(all_of FeatureIdxHalf),
-                                      "index half regs">;
+                   AssemblerPredicate<"FeatureIdxHalf", "index half regs">;
+def HaveSliOps   : Predicate<"Subtarget->hasSliOps()">,
+                   AssemblerPredicate<"FeatureSli", "sli ops">;
 
 //===----------------------------------------------------------------------===//
 // Z80 Instruction Format Definitions.
@@ -805,6 +807,8 @@ defm RL  : UnOp8RFF <CBPre, 2, "rl">;
 defm RR  : UnOp8RFF <CBPre, 3, "rr">;
 defm SLA : UnOp8RF  <CBPre, 4, "sla">;
 defm SRA : UnOp8RF  <CBPre, 5, "sra">;
+defm SLI : UnOp8RF  <CBPre, 6, "sli">,
+           Requires<[HaveSliOps]>;
 defm SRL : UnOp8RF  <CBPre, 7, "srl">;
 defm BIT : BitOp8F  <       1, "bit">;
 defm RES : BitOp8R  <       2, "res">;
@@ -820,7 +824,9 @@ defm XOR : BinOp8RF <NoPre, 5, "xor">;
 defm OR  : BinOp8RF <NoPre, 6, "or",  1>;
 defm CP  : BinOp8F  <NoPre, 7, "cp",  1>;
 defm TST : BinOp8F  <EDPre, 4, "tst", 1>,
-           Requires<[HaveEZ80Ops]>;
+           Requires<[HaveZ180Ops]>;
+
+def : MnemonicAlias<"sll", "sli">, Requires<[HaveSliOps]>;
 
 def : Pat<(fshl G8:$reg, G8:$reg, (i8  1)), (RLC8r G8:$reg)>;
 def : Pat<(fshl G8:$reg, G8:$reg, (i8  7)), (RRC8r G8:$reg)>;

--- a/llvm/lib/Target/Z80/Z80InstrInfo.td
+++ b/llvm/lib/Target/Z80/Z80InstrInfo.td
@@ -133,9 +133,10 @@ def HaveZ180Ops  : Predicate<"Subtarget->hasZ180Ops()">,
 def HaveEZ80Ops  : Predicate<"Subtarget->hasEZ80Ops()">,
                    AssemblerPredicate<(all_of FeatureEZ80), "eZ80 ops">;
 def HaveIdxHalf  : Predicate<"Subtarget->hasIndexHalfRegs()">,
-                   AssemblerPredicate<"FeatureIdxHalf", "index half regs">;
-def HaveSliOps   : Predicate<"Subtarget->hasSliOps()">,
-                   AssemblerPredicate<"FeatureSli", "sli ops">;
+                   AssemblerPredicate<(all_of FeatureIdxHalf),
+                                      "index half regs">;
+def HaveSliOp    : Predicate<"Subtarget->hasSliOp()">,
+                   AssemblerPredicate<(all_of FeatureSli), "SLI op">;
 
 //===----------------------------------------------------------------------===//
 // Z80 Instruction Format Definitions.
@@ -807,8 +808,7 @@ defm RL  : UnOp8RFF <CBPre, 2, "rl">;
 defm RR  : UnOp8RFF <CBPre, 3, "rr">;
 defm SLA : UnOp8RF  <CBPre, 4, "sla">;
 defm SRA : UnOp8RF  <CBPre, 5, "sra">;
-defm SLI : UnOp8RF  <CBPre, 6, "sli">,
-           Requires<[HaveSliOps]>;
+defm SLI : UnOp8RF  <CBPre, 6, "sli">, Requires<[HaveSliOp]>;
 defm SRL : UnOp8RF  <CBPre, 7, "srl">;
 defm BIT : BitOp8F  <       1, "bit">;
 defm RES : BitOp8R  <       2, "res">;
@@ -823,15 +823,17 @@ defm AND : BinOp8RF <NoPre, 4, "and">;
 defm XOR : BinOp8RF <NoPre, 5, "xor">;
 defm OR  : BinOp8RF <NoPre, 6, "or",  1>;
 defm CP  : BinOp8F  <NoPre, 7, "cp",  1>;
-defm TST : BinOp8F  <EDPre, 4, "tst", 1>,
-           Requires<[HaveZ180Ops]>;
+defm TST : BinOp8F  <EDPre, 4, "tst", 1>, Requires<[HaveZ180Ops]>;
 
-def : MnemonicAlias<"sll", "sli">, Requires<[HaveSliOps]>;
+def : MnemonicAlias<"sll", "sli">, Requires<[HaveSliOp]>;
+def : MnemonicAlias<"sl1", "sli">, Requires<[HaveSliOp]>;
 
 def : Pat<(fshl G8:$reg, G8:$reg, (i8  1)), (RLC8r G8:$reg)>;
 def : Pat<(fshl G8:$reg, G8:$reg, (i8  7)), (RRC8r G8:$reg)>;
 def : Pat<(shl G8:$reg, (i8  1)), (SLA8r G8:$reg)>;
 def : Pat<(sra G8:$reg, (i8  1)), (SRA8r G8:$reg)>;
+def : Pat<(or (shl G8:$reg, (i8  1)), (i8  1)), (SLI8r G8:$reg)>,
+      Requires<[HaveSliOp]>;
 def : Pat<(srl G8:$reg, (i8  1)), (SRL8r G8:$reg)>;
 def : Pat<(add R8:$reg, (i8  1)), (INC8r R8:$reg)>;
 def : Pat<(add R8:$reg, (i8 -1)), (DEC8r R8:$reg)>;

--- a/llvm/lib/Target/Z80/Z80Subtarget.cpp
+++ b/llvm/lib/Target/Z80/Z80Subtarget.cpp
@@ -35,7 +35,7 @@ Z80Subtarget &Z80Subtarget::initializeSubtargetDependencies(StringRef CPU,
     CPU = TargetTriple.getArchName();
   ParseSubtargetFeatures(CPU, TuneCPU, FS);
   HasIdxHalfRegs = HasUndocOps || HasEZ80Ops;
-  HasSliOps = HasUndocOps;
+  HasSliOp = HasUndocOps;
   return *this;
 }
 

--- a/llvm/lib/Target/Z80/Z80Subtarget.cpp
+++ b/llvm/lib/Target/Z80/Z80Subtarget.cpp
@@ -35,6 +35,7 @@ Z80Subtarget &Z80Subtarget::initializeSubtargetDependencies(StringRef CPU,
     CPU = TargetTriple.getArchName();
   ParseSubtargetFeatures(CPU, TuneCPU, FS);
   HasIdxHalfRegs = HasUndocOps || HasEZ80Ops;
+  HasSliOps = HasUndocOps;
   return *this;
 }
 

--- a/llvm/lib/Target/Z80/Z80Subtarget.h
+++ b/llvm/lib/Target/Z80/Z80Subtarget.h
@@ -52,8 +52,8 @@ class Z80Subtarget final : public Z80GenSubtargetInfo {
   /// True if target has index half registers (HasUndocOps || HasEZ80Ops).
   bool HasIdxHalfRegs = false;
 
-  /// True if target has SLI (also known SLL) instructions (HasUndocOps)
-  bool HasSliOps = false;
+  /// True if target has SLI (also known SLL and SL1) instruction (HasUndocOps)
+  bool HasSliOp = false;
 
   // Ordering here is important. Z80InstrInfo initializes Z80RegisterInfo which
   // Z80TargetLowering needs.
@@ -121,7 +121,7 @@ public:
   bool hasZ180Ops() const { return HasZ180Ops; }
   bool hasEZ80Ops() const { return HasEZ80Ops; }
   bool hasIndexHalfRegs() const { return HasIdxHalfRegs; }
-  bool hasSliOps() const { return HasSliOps; }
+  bool hasSliOp() const { return HasSliOp; }
   bool has24BitEZ80Ops() const { return is24Bit() && hasEZ80Ops(); }
   bool has16BitEZ80Ops() const { return is16Bit() && hasEZ80Ops(); }
 };

--- a/llvm/lib/Target/Z80/Z80Subtarget.h
+++ b/llvm/lib/Target/Z80/Z80Subtarget.h
@@ -52,6 +52,9 @@ class Z80Subtarget final : public Z80GenSubtargetInfo {
   /// True if target has index half registers (HasUndocOps || HasEZ80Ops).
   bool HasIdxHalfRegs = false;
 
+  /// True if target has SLI (also known SLL) instructions (HasUndocOps)
+  bool HasSliOps = false;
+
   // Ordering here is important. Z80InstrInfo initializes Z80RegisterInfo which
   // Z80TargetLowering needs.
   Z80InstrInfo InstrInfo;
@@ -118,6 +121,7 @@ public:
   bool hasZ180Ops() const { return HasZ180Ops; }
   bool hasEZ80Ops() const { return HasEZ80Ops; }
   bool hasIndexHalfRegs() const { return HasIdxHalfRegs; }
+  bool hasSliOps() const { return HasSliOps; }
   bool has24BitEZ80Ops() const { return is24Bit() && hasEZ80Ops(); }
   bool has16BitEZ80Ops() const { return is16Bit() && hasEZ80Ops(); }
 };


### PR DESCRIPTION
Also this patch contains fix for requirements for TST instruction (it is documented since Z180).